### PR TITLE
[WIP] feat: add StepFun provider support

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -48,6 +48,7 @@
   "usage_env_eval": "Usage: env [model] - Output export statements only (for eval), no plaintext keys",
   "longcat_features": "Official: LongCat-Flash-Thinking / LongCat-Flash-Chat",
   "glm_features": "Official: glm-4.5 / glm-4.5-air",
+  "stepfun_features": "StepFun: step-3.5-flash",
   "claude_sonnet_features": "claude-sonnet-4-20250514",
   "claude_opus_features": "claude-opus-4-6",
   "using_pro_subscription": "using Claude Pro subscription",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -48,6 +48,7 @@
   "usage_env_eval": "用法: env [模型] - 仅输出 export 语句（用于 eval），不打印密钥明文",
   "longcat_features": "官方：LongCat-Flash-Thinking / LongCat-Flash-Chat",
   "glm_features": "官方：glm-4.5 / glm-4.5-air",
+  "stepfun_features": "StepFun：step-3.5-flash",
   "claude_sonnet_features": "claude-sonnet-4-20250514",
   "claude_opus_features": "claude-opus-4-6",
   "using_pro_subscription": "使用 Claude Pro 订阅",


### PR DESCRIPTION
Add support for StepFun API with step-3.5-flash model.

Changes:
- Add STEPFUN_API_KEY and STEPFUN_MODEL to config templates
- Add stepfun case to get_provider_config() for user-level settings
- Add stepfun case to emit_env_exports() for environment switching
- Add stepfun to show_status() for API key status display
- Add stepfun to show_help() for documentation
- Add stepfun routing in main() command handler
- Add stepfun to user command providers list
- Add STEPFUN_MODEL to ensure_model_override_defaults()
- Add stepfun_features translation to en.json and zh.json

Usage:
  ccm stepfun          # Switch to StepFun model
  ccm user stepfun     # Set StepFun as default user-level