### PR TITLE
Fix/openrouter supports for minimax-2.5/step-3.5-flash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,19 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Conversation Style
+
+**Roleplay Setting:**
+- **User (主公/Lord)**: The master who gives commands and makes decisions
+- **Claude (臣子/Subject)**: The loyal assistant who serves and advises
+
+When interacting, maintain this relationship dynamics:
+- Be respectful and attentive
+- Provide clear, actionable advice
+- Wait for the lord's decisions
+- Use polite, formal tone when appropriate
+- Be ready to step back when dismissed
+
 ## Project Overview
 
 **Claude Code Switch (CCM)** is a Bash-based CLI that switches Claude Code between providers/models by exporting Anthropic-compatible environment variables. There is no automatic fallback; OpenRouter is an explicit command.

--- a/README.md
+++ b/README.md
@@ -180,10 +180,19 @@ ccm seed kimi         # kimi-k2.5
 ### OpenRouter
 ```bash
 ccm open              # Show help
-ccm open glm          # GLM via OpenRouter
 ccm open claude       # Claude via OpenRouter
+ccm open glm          # GLM via OpenRouter
+ccm open kimi         # Kimi via OpenRouter
 ccm open deepseek     # DeepSeek via OpenRouter
+ccm open qwen         # Qwen via OpenRouter
+ccm open minimax      # MiniMax via OpenRouter
+ccm open stepfun      # StepFun via OpenRouter
+ccm open sf-free      # StepFun free tier
 ```
+
+**Available providers:** `claude`, `glm`, `kimi`, `deepseek`, `qwen`, `minimax`, `stepfun`
+
+**Free tier:** `stepfun-free` or `sf-free` for StepFun's free model
 
 ---
 

--- a/ccm.sh
+++ b/ccm.sh
@@ -1363,6 +1363,7 @@ show_status() {
                     *deepseek*) echo "   Provider: $(t 'openrouter_provider_deepseek')" ;;
                     *minimax*) echo "   Provider: $(t 'openrouter_provider_minimax')" ;;
                     *qwen*) echo "   Provider: $(t 'openrouter_provider_qwen')" ;;
+                    *stepfun*) echo "   Provider: $(t 'openrouter_provider_stepfun')" ;;
                     *claude*|*anthropic*) echo "   Provider: $(t 'openrouter_provider_claude')" ;;
                     *) echo "   Provider: $(t 'openrouter_provider_unknown') ${ANTHROPIC_MODEL})" ;;
                 esac
@@ -1856,7 +1857,7 @@ show_open_help() {
     echo "  ccm open <provider>"
     echo ""
     echo -e "${YELLOW}Supported providers:${NC}"
-    echo "  claude (default), deepseek, kimi, glm, qwen, minimax"
+    echo "  claude (default), deepseek, kimi, glm, qwen, minimax, stepfun"
     echo ""
     echo -e "${YELLOW}Examples:${NC}"
     echo "  eval \"\$(ccm open claude)\""
@@ -1922,6 +1923,13 @@ emit_openrouter_exports() {
         "minimax"|"mm")
             model="minimax/minimax-m2.5"
             small="minimax/minimax-m2.5"
+            default_sonnet="$model"
+            default_opus="$model"
+            default_haiku="$model"
+            ;;
+        "stepfun"|"sf")
+            model="stepfun/step-3.5-flash"
+            small="stepfun/step-3.5-flash"
             default_sonnet="$model"
             default_opus="$model"
             default_haiku="$model"

--- a/ccm.sh
+++ b/ccm.sh
@@ -1920,8 +1920,8 @@ emit_openrouter_exports() {
             default_haiku="qwen/qwen3-coder-next"
             ;;
         "minimax"|"mm")
-            model="minimax/minimax-m2.1"
-            small="minimax/minimax-m2.1"
+            model="minimax/minimax-m2.5"
+            small="minimax/minimax-m2.5"
             default_sonnet="$model"
             default_opus="$model"
             default_haiku="$model"

--- a/ccm.sh
+++ b/ccm.sh
@@ -1348,6 +1348,30 @@ show_status() {
         fi
     fi
 
+    # OpenRouter Configuration
+    if is_effectively_set "$OPENROUTER_API_KEY"; then
+        echo -e "${BLUE}🌐 OpenRouter:${NC}"
+        if [[ "${ANTHROPIC_BASE_URL:-}" == *"openrouter"* ]]; then
+            echo -e "   ${GREEN}Status:${NC} $(t 'openrouter_active')"
+            echo "   MODEL: ${ANTHROPIC_MODEL:-'(not set)'}"
+            echo "   SUBAGENT_MODEL: ${CLAUDE_CODE_SUBAGENT_MODEL:-'(not set)'}"
+            # Detect provider from model name
+            if [[ -n "${ANTHROPIC_MODEL:-}" ]]; then
+                case "$ANTHROPIC_MODEL" in
+                    *glm*) echo "   Provider: $(t 'openrouter_provider_glm')" ;;
+                    *kimi*) echo "   Provider: $(t 'openrouter_provider_kimi')" ;;
+                    *deepseek*) echo "   Provider: $(t 'openrouter_provider_deepseek')" ;;
+                    *claude*|*anthropic*) echo "   Provider: $(t 'openrouter_provider_claude')" ;;
+                    *) echo "   Provider: $(t 'openrouter_provider_unknown') ${ANTHROPIC_MODEL})" ;;
+                esac
+            fi
+        else
+            echo -e "   ${YELLOW}Status:${NC} $(t 'openrouter_configured_not_active')"
+            echo -e "${YELLOW}   💡 $(t 'openrouter_use_eval_hint')${NC}"
+        fi
+        echo ""
+    fi
+
     echo -e "${BLUE}📊 $(t 'current_model_config'):${NC}"
     echo "   BASE_URL: ${ANTHROPIC_BASE_URL:-'Default (Anthropic)'}"
     echo -n "   AUTH_TOKEN: "

--- a/ccm.sh
+++ b/ccm.sh
@@ -1365,7 +1365,7 @@ show_status() {
                     *qwen*) echo "   Provider: $(t 'openrouter_provider_qwen')" ;;
                     *stepfun*)
                         echo "   Provider: $(t 'openrouter_provider_stepfun')"
-                        [[ "$ANTHROPIC_MODEL" == *":free" ]] && echo "   ${GREEN}🆓 Free Tier${NC}"
+                        [[ "$ANTHROPIC_MODEL" == *":free" ]] && echo -e "   ${GREEN}🆓 Free Tier${NC}"
                         ;;
                     *claude*|*anthropic*) echo "   Provider: $(t 'openrouter_provider_claude')" ;;
                     *) echo "   Provider: $(t 'openrouter_provider_unknown') ${ANTHROPIC_MODEL})" ;;

--- a/ccm.sh
+++ b/ccm.sh
@@ -1361,6 +1361,8 @@ show_status() {
                     *glm*) echo "   Provider: $(t 'openrouter_provider_glm')" ;;
                     *kimi*) echo "   Provider: $(t 'openrouter_provider_kimi')" ;;
                     *deepseek*) echo "   Provider: $(t 'openrouter_provider_deepseek')" ;;
+                    *minimax*) echo "   Provider: $(t 'openrouter_provider_minimax')" ;;
+                    *qwen*) echo "   Provider: $(t 'openrouter_provider_qwen')" ;;
                     *claude*|*anthropic*) echo "   Provider: $(t 'openrouter_provider_claude')" ;;
                     *) echo "   Provider: $(t 'openrouter_provider_unknown') ${ANTHROPIC_MODEL})" ;;
                 esac

--- a/ccm.sh
+++ b/ccm.sh
@@ -1363,7 +1363,10 @@ show_status() {
                     *deepseek*) echo "   Provider: $(t 'openrouter_provider_deepseek')" ;;
                     *minimax*) echo "   Provider: $(t 'openrouter_provider_minimax')" ;;
                     *qwen*) echo "   Provider: $(t 'openrouter_provider_qwen')" ;;
-                    *stepfun*) echo "   Provider: $(t 'openrouter_provider_stepfun')" ;;
+                    *stepfun*)
+                        echo "   Provider: $(t 'openrouter_provider_stepfun')"
+                        [[ "$ANTHROPIC_MODEL" == *":free" ]] && echo "   ${GREEN}🆓 Free Tier${NC}"
+                        ;;
                     *claude*|*anthropic*) echo "   Provider: $(t 'openrouter_provider_claude')" ;;
                     *) echo "   Provider: $(t 'openrouter_provider_unknown') ${ANTHROPIC_MODEL})" ;;
                 esac
@@ -1859,9 +1862,13 @@ show_open_help() {
     echo -e "${YELLOW}Supported providers:${NC}"
     echo "  claude (default), deepseek, kimi, glm, qwen, minimax, stepfun"
     echo ""
+    echo -e "${YELLOW}Free tier:${NC}"
+    echo "  stepfun-free (sf-free) - stepfun/step-3.5-flash:free"
+    echo ""
     echo -e "${YELLOW}Examples:${NC}"
     echo "  eval \"\$(ccm open claude)\""
     echo "  eval \"\$(ccm open kimi)\""
+    echo "  eval \"\$(ccm open sf-free)\""
 }
 
 emit_openrouter_exports() {
@@ -1930,6 +1937,13 @@ emit_openrouter_exports() {
         "stepfun"|"sf")
             model="stepfun/step-3.5-flash"
             small="stepfun/step-3.5-flash"
+            default_sonnet="$model"
+            default_opus="$model"
+            default_haiku="$model"
+            ;;
+        "stepfun-free"|"sf-free")
+            model="stepfun/step-3.5-flash:free"
+            small="stepfun/step-3.5-flash:free"
             default_sonnet="$model"
             default_opus="$model"
             default_haiku="$model"

--- a/lang/en.json
+++ b/lang/en.json
@@ -109,6 +109,8 @@
   "openrouter_provider_glm": "GLM (via OpenRouter)",
   "openrouter_provider_kimi": "Kimi (via OpenRouter)",
   "openrouter_provider_deepseek": "DeepSeek (via OpenRouter)",
+  "openrouter_provider_minimax": "MiniMax (via OpenRouter)",
+  "openrouter_provider_qwen": "Qwen (via OpenRouter)",
   "openrouter_provider_claude": "Claude (via OpenRouter)",
   "openrouter_provider_unknown": "Unknown (model:"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -102,5 +102,13 @@
   "custom_proxy": "Custom Proxy",
   "base_url_config_note": "BASE URL can be changed via CLAUDE_PROXY_BASE_URL environment variable or config file",
   "custom": "(custom)",
-  "project_config": "Project config detected"
+  "project_config": "Project config detected",
+  "openrouter_active": "Active",
+  "openrouter_configured_not_active": "Configured but not active",
+  "openrouter_use_eval_hint": "Use 'eval $(ccm open <provider>)' to activate",
+  "openrouter_provider_glm": "GLM (via OpenRouter)",
+  "openrouter_provider_kimi": "Kimi (via OpenRouter)",
+  "openrouter_provider_deepseek": "DeepSeek (via OpenRouter)",
+  "openrouter_provider_claude": "Claude (via OpenRouter)",
+  "openrouter_provider_unknown": "Unknown (model:"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -48,6 +48,7 @@
   "usage_env_eval": "Usage: env [model] - Output export statements only (for eval), no plaintext keys",
   "longcat_features": "Official: LongCat-Flash-Thinking / LongCat-Flash-Chat",
   "glm_features": "Official: glm-4.5 / glm-4.5-air",
+  "stepfun_features": "StepFun: step-3.5-flash",
   "claude_sonnet_features": "claude-sonnet-4-20250514",
   "claude_opus_features": "claude-opus-4-6",
   "using_pro_subscription": "using Claude Pro subscription",

--- a/lang/en.json
+++ b/lang/en.json
@@ -111,6 +111,7 @@
   "openrouter_provider_deepseek": "DeepSeek (via OpenRouter)",
   "openrouter_provider_minimax": "MiniMax (via OpenRouter)",
   "openrouter_provider_qwen": "Qwen (via OpenRouter)",
+  "openrouter_provider_stepfun": "StepFun (via OpenRouter)",
   "openrouter_provider_claude": "Claude (via OpenRouter)",
   "openrouter_provider_unknown": "Unknown (model:"
 }

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -109,6 +109,8 @@
   "openrouter_provider_glm": "GLM (通过 OpenRouter)",
   "openrouter_provider_kimi": "Kimi (通过 OpenRouter)",
   "openrouter_provider_deepseek": "DeepSeek (通过 OpenRouter)",
+  "openrouter_provider_minimax": "MiniMax (通过 OpenRouter)",
+  "openrouter_provider_qwen": "Qwen (通过 OpenRouter)",
   "openrouter_provider_claude": "Claude (通过 OpenRouter)",
   "openrouter_provider_unknown": "未知 (模型:"
 }

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -102,5 +102,13 @@
   "custom_proxy": "自定义代理",
   "base_url_config_note": "BASE URL可通过 CLAUDE_PROXY_BASE_URL 环境变量或配置文件修改",
   "custom": "（自定义）",
-  "project_config": "检测到项目配置"
+  "project_config": "检测到项目配置",
+  "openrouter_active": "已激活",
+  "openrouter_configured_not_active": "已配置但未激活",
+  "openrouter_use_eval_hint": "使用 'eval $(ccm open <provider>)' 激活",
+  "openrouter_provider_glm": "GLM (通过 OpenRouter)",
+  "openrouter_provider_kimi": "Kimi (通过 OpenRouter)",
+  "openrouter_provider_deepseek": "DeepSeek (通过 OpenRouter)",
+  "openrouter_provider_claude": "Claude (通过 OpenRouter)",
+  "openrouter_provider_unknown": "未知 (模型:"
 }

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -111,6 +111,7 @@
   "openrouter_provider_deepseek": "DeepSeek (通过 OpenRouter)",
   "openrouter_provider_minimax": "MiniMax (通过 OpenRouter)",
   "openrouter_provider_qwen": "Qwen (通过 OpenRouter)",
+  "openrouter_provider_stepfun": "StepFun (通过 OpenRouter)",
   "openrouter_provider_claude": "Claude (通过 OpenRouter)",
   "openrouter_provider_unknown": "未知 (模型:"
 }

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -48,6 +48,7 @@
   "usage_env_eval": "用法: env [模型] - 仅输出 export 语句（用于 eval），不打印密钥明文",
   "longcat_features": "官方：LongCat-Flash-Thinking / LongCat-Flash-Chat",
   "glm_features": "官方：glm-4.5 / glm-4.5-air",
+  "stepfun_features": "StepFun：step-3.5-flash",
   "claude_sonnet_features": "claude-sonnet-4-20250514",
   "claude_opus_features": "claude-opus-4-6",
   "using_pro_subscription": "使用 Claude Pro 订阅",


### PR DESCRIPTION
Fixes: #16  and partially #15                                                                                                                                     

  ## Summary

  Fixed the OpenRouter status display issue where ccm status did not properly show model configuration after using eval $(ccm open <provider>). Also added
  support for additional providers (MiniMax, Qwen, StepFun) and free tier models.

  ## Problem

  After running eval $(ccm open glm), the status showed:
  - MODEL: 'Not set'
  - SUBAGENT_MODEL: 'Not set'

  This was confusing because OpenRouter was working, but the configuration wasn't visible in the status output.

  ## Solution

  Added a dedicated OpenRouter section to show_status() that:
  - Shows when OPENROUTER_API_KEY is configured
  - Displays "Active" status when BASE_URL points to OpenRouter
  - Shows model and subagent model information
  - Detects and displays provider from model name (GLM, Kimi, DeepSeek, MiniMax, Qwen, StepFun, Claude)
  - Shows "Configured but not active" when API key is set but OpenRouter is not active
  - Provides helpful hint: "Use 'eval $(ccm open )' to activate"

 ## Changes

  - OpenRouter Status Section - Added dedicated section to show_status() showing active/inactive status
  - Provider Detection - Added MiniMax, Qwen, StepFun patterns (previously showed as "Unknown")
  - MiniMax Model Fix - Updated from minimax-m2.1 to minimax-m2.5
  - StepFun Support - Added stepfun/step-3.5-flash provider
  - Free Tier - Added stepfun-free / sf-free aliases for free models with visual indicator (🆓)
  - Documentation - Updated README with all available providers

  ## Before/After

  Before:
  📊 Current model configuration:
     MODEL: 'Not set'
     SUBAGENT_MODEL: 'Not set'

  After:
  🌐 OpenRouter:
     Status: Active
     MODEL: stepfun/step-3.5-flash:free
     SUBAGENT_MODEL: stepfun/step-3.5-flash:free
     Provider: StepFun (via OpenRouter)
     🆓 Free Tier

  📊 Current model configuration:
     BASE_URL: https://openrouter.ai/api
     MODEL: stepfun/step-3.5-flash:free
     SUBAGENT_MODEL: stepfun/step-3.5-flash:free

  ## Usage

  ### Configure OpenRouter API key
  export OPENROUTER_API_KEY=sk-or-...

  ### Available providers
  eval "$(ccm open claude)"       # Claude Sonnet 4.5
  eval "$(ccm open glm)"          # GLM-5
  eval "$(ccm open kimi)"         # Kimi K2.5
  eval "$(ccm open deepseek)"     # DeepSeek V3.2
  eval "$(ccm open qwen)"         # Qwen3 Coder
  eval "$(ccm open minimax)"      # MiniMax M2.5
  eval "$(ccm open stepfun)"      # StepFun 3.5 Flash
  eval "$(ccm open sf-free)"      # StepFun Free Tier

  ### Check status
  ccm status

  ## Commits

  - fix(ccm): add OpenRouter status display to show_status command
  - fix(ccm): add missing MiniMax and Qwen provider detection
  - fix(openrouter): update MiniMax model from m2.1 to m2.5
  - feat(openrouter): add StepFun provider support
  - feat(openrouter): add free tier support for StepFun
  - fix(openrouter): use echo -e for free tier color codes
  - docs: update OpenRouter section in README

  ## Testing

  eval "$(ccm open sf-free)"
  ccm status

  Expected output should show the OpenRouter section with active status, model info, provider detection, and free tier indicator.