### PR TITLE
fix: bash 3.2 heredoc bug causes unbound variable on macOS install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -481,7 +481,7 @@ exec "$CCM_SH" "$@"
 EOF
   else
     local content
-    content="$(cat <<'EOF'
+    IFS= read -r -d '' content <<'EOF' || true
 #!/usr/bin/env bash
 set -euo pipefail
 CCM_SH="__DATA_DIR__/ccm.sh"
@@ -491,7 +491,6 @@ if [[ ! -f "$CCM_SH" ]]; then
 fi
 exec "$CCM_SH" "$@"
 EOF
-)"
     content="${content//__DATA_DIR__/$data_dir}"
     printf '%s\n' "$content" > "$target"
   fi
@@ -631,7 +630,7 @@ fi
 EOF
   else
     local content
-    content="$(cat <<'EOF'
+    IFS= read -r -d '' content <<'EOF' || true
 #!/usr/bin/env bash
 set -euo pipefail
 CCM="__DATA_DIR__/ccm.sh"
@@ -751,7 +750,6 @@ else
     exec claude "${claude_args[@]}"
 fi
 EOF
-)"
     content="${content//__DATA_DIR__/$data_dir}"
     printf '%s\n' "$content" > "$target"
   fi


### PR DESCRIPTION
## Summary

- Fix `./install.sh: line 702: account: unbound variable` error on macOS (bash 3.2)
- Root cause: bash 3.2 has a bug where `"$(cat <<'DELIM'...DELIM)"` incorrectly expands variables after a `case/esac` block inside a single-quoted heredoc, triggering `set -u`
- Replace `content="$(cat <<'EOF'...EOF)"` with `IFS= read -r -d '' content <<'EOF' || true` in both `write_ccm_wrapper` and `write_ccc_wrapper` to avoid command substitution entirely

## Test plan

- [x] Verified fix on macOS with bash 3.2.57 (Apple default)
- [x] `bash -n install.sh` passes syntax check
- [x] Interactive install (`./install.sh`) completes without error
- [x] Generated `ccm` and `ccc` wrappers contain correct content